### PR TITLE
Limit the minimum window size to 1000x680

### DIFF
--- a/Loaf/Loaf.csproj
+++ b/Loaf/Loaf.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.4.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
+    <PackageReference Include="PInvoke.User32" Version="0.7.104" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/Loaf/MainWindow.xaml.cs
+++ b/Loaf/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using System;
 using System.Runtime.InteropServices;
+using WinRT.Interop;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
@@ -17,10 +18,15 @@ namespace Loaf
     public sealed partial class MainWindow : Window
     {
         private bool _isLoafing;
+        private WinProc _newWndProc = null;
+        private IntPtr _oldWndProc = IntPtr.Zero;
+        private const int MIN_WINDOW_WIDTH = 1000;
+        private const int MIN_WINDOW_HEIGHT = 680;
 
         public MainWindow()
         {
             this.InitializeComponent();
+            SubClassing();
             Instance = this;
             Root.Loaded += OnLoaded;
             Root.KeyDown += Root_KeyDown;
@@ -50,10 +56,11 @@ namespace Loaf
             Frame.Navigate(typeof(MainView));
             _appWindow = GetAppWindowForCurrentWindow();
 
-            _appWindow.Title = "WinUI ❤️ "+ResourceExtensions.GetLocalized("Loaf");
+            _appWindow.Title = "WinUI ❤️ " + ResourceExtensions.GetLocalized("Loaf");
         }
 
         private AppWindow _appWindow;
+        private delegate IntPtr WinProc(IntPtr hWnd, PInvoke.User32.WindowMessage msg, IntPtr wParam, IntPtr lParam);
 
         public void Loaf()
         {
@@ -69,7 +76,7 @@ namespace Loaf
                 parent = VisualTreeHelper.GetParent(parent);
             }
             Frame.Navigate(typeof(Windows11UpdateView));
-            
+
             _appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
             while (ShowCursor(true) < 0)
             {
@@ -88,7 +95,7 @@ namespace Loaf
         {
             _isLoafing = false;
             _appWindow.SetPresenter(AppWindowPresenterKind.Default);
-            var parent = VisualTreeHelper.GetParent(Root); 
+            var parent = VisualTreeHelper.GetParent(Root);
             while (parent != null)
             {
                 if (parent is FrameworkElement element)
@@ -109,20 +116,56 @@ namespace Loaf
         [DllImport("user32", EntryPoint = "ShowCursor")]
         public extern static int ShowCursor(bool show);
 
+        [DllImport("user32")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, PInvoke.User32.WindowLongIndexFlags nIndex, WinProc newProc);
+
         [DllImport("user32.dll", EntryPoint = "ShowWindow")]
         public static extern int ShowWindow(IntPtr hwnd, int nCmdShow);
 
+        [DllImport("user32.dll")]
+        internal static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, PInvoke.User32.WindowMessage msg, IntPtr wParam, IntPtr lParam);
+
         private AppWindow GetAppWindowForCurrentWindow()
         {
-            IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            WindowId myWndId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+            IntPtr hWnd = WindowNative.GetWindowHandle(this);
+            WindowId myWndId = Win32Interop.GetWindowIdFromWindow(hWnd);
             return AppWindow.GetFromWindowId(myWndId);
         }
 
         private void RestoreWindow()
         {
-            IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            IntPtr hWnd = WindowNative.GetWindowHandle(this);
             ShowWindow(hWnd, 9);
+        }
+
+        private void SubClassing()
+        {
+            var windowHandle = WindowNative.GetWindowHandle(this);
+            _newWndProc = new WinProc(NewWindowProc);
+            _oldWndProc = SetWindowLongPtr(windowHandle, PInvoke.User32.WindowLongIndexFlags.GWL_WNDPROC, _newWndProc);
+        }
+
+        private IntPtr NewWindowProc(IntPtr hWnd, PInvoke.User32.WindowMessage msg, IntPtr wParam, IntPtr lParam)
+        {
+            switch (msg)
+            {
+                case PInvoke.User32.WindowMessage.WM_GETMINMAXINFO:
+                    {
+                        var minMaxInfo = Marshal.PtrToStructure<PInvoke.User32.MINMAXINFO>(lParam);
+                        minMaxInfo.ptMinTrackSize.x = GetActualPixel(MIN_WINDOW_WIDTH, hWnd);
+                        minMaxInfo.ptMinTrackSize.y = GetActualPixel(MIN_WINDOW_HEIGHT, hWnd);
+                        Marshal.StructureToPtr(minMaxInfo, lParam, true);
+                        break;
+                    }
+            }
+
+            return CallWindowProc(_oldWndProc, hWnd, msg, wParam, lParam);
+        }
+
+        private static int GetActualPixel(double pixel, IntPtr windowHandle)
+        {
+            var dpi = PInvoke.User32.GetDpiForWindow(windowHandle);
+            return Convert.ToInt32(pixel * (dpi / 96.0));
         }
     }
 }


### PR DESCRIPTION
**做了什么**

将应用窗口的最小大小设置为 1000 x 680。该大小足以显示应用内容，且包含一定范围的背景色。

**为什么这么做？**

目前应用没有适应不同窗口大小的布局，缩小窗口会截断内容。

**怎么做的？**

目前 Windows App SDK 还没有公开简单的设置窗口最小大小的 API，所以还是走的 Win32 的路子，监听特定的系统消息 `WM_GETMINMAXINFO` ，并传回特定的 Size，以达到设置最小窗口大小的目的。

**截图**

![image](https://user-images.githubusercontent.com/27713596/146723032-0a0abd96-aa85-4a6e-a943-960b89ed08d2.png)
