### PR TITLE
添加 Mica 材质支持

### DIFF
--- a/Loaf/Controls/AppTitleBar.xaml
+++ b/Loaf/Controls/AppTitleBar.xaml
@@ -24,23 +24,25 @@
         </Style>
     </UserControl.Resources>
 
-    <Grid
-        MinHeight="36"
-        Padding="4,0,0,0"
-        Background="{ThemeResource WindowHostBrush}"
-        ColumnSpacing="8">
+    <Grid MinHeight="36" ColumnSpacing="4">
         <Grid.ColumnDefinitions>
             <!--  Back button  -->
             <ColumnDefinition Width="Auto" />
             <!--  Logo  -->
-            <ColumnDefinition x:Name="LogoColumn" Width="*" />
+            <ColumnDefinition x:Name="LogoColumn" Width="Auto" />
             <!--  Flex  -->
-            <ColumnDefinition Width="40" />
+            <ColumnDefinition x:Name="FlexColumn" Width="*" />
         </Grid.ColumnDefinitions>
+
+        <Rectangle
+            x:Name="TitleBarHost"
+            Grid.ColumnSpan="3"
+            MinHeight="36"
+            Fill="Transparent" />
 
         <Button
             x:Name="BackButton"
-            Margin="0,4,0,0"
+            Margin="2,0,0,0"
             Click="OnBackButtonClickAsync"
             Style="{StaticResource TitleBarButtonStyle}"
             Visibility="{x:Bind IsShowBackButton, Mode=OneWay}">
@@ -66,12 +68,12 @@
         <StackPanel
             x:Name="LogoArea"
             Grid.Column="1"
-            Margin="0,4,0,0"
+            Margin="8,0,0,0"
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
             IsHitTestVisible="False"
             Orientation="Horizontal"
-            Spacing="8">
+            Spacing="16">
             <Image
                 Width="16"
                 Height="16"

--- a/Loaf/Controls/AppTitleBar.xaml.cs
+++ b/Loaf/Controls/AppTitleBar.xaml.cs
@@ -1,16 +1,23 @@
-﻿using Microsoft.UI.Xaml;
+﻿using Loaf.Utils;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using Windows.Graphics;
 
 namespace Loaf.Controls
 {
     public sealed partial class AppTitleBar : UserControl
     {
         public event EventHandler BackButtonClick;
+        private AppWindowTitleBar _appWindowTitleBar;
 
         public AppTitleBar()
         {
             this.InitializeComponent();
+            ActualThemeChanged += OnActualThemeChanged;
+            Loaded += OnLoaded;
+            SizeChanged += OnSizeChanged;
         }
 
         public bool IsShowBackButton
@@ -21,6 +28,33 @@ namespace Loaf.Controls
 
         public static readonly DependencyProperty IsShowBackButtonProperty =
             DependencyProperty.Register(nameof(IsShowBackButton), typeof(bool), typeof(AppTitleBar), new PropertyMetadata(false));
+
+        private void OnActualThemeChanged(FrameworkElement sender, object args)
+            => AppUtils.InitializeTitleBar(AppUtils.AppWindow.TitleBar);
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+            => SetDragArea();
+
+        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+            => SetDragArea();
+
+        private void SetDragArea()
+        {
+            var appWindow = AppUtils.AppWindow;
+            _appWindowTitleBar = appWindow.TitleBar;
+            if (_appWindowTitleBar == null)
+            {
+                return;
+            }
+
+            var dragRect = default(RectInt32);
+            dragRect.X = AppUtils.GetScalePixel(40, AppUtils.MainWindowHandle);
+            dragRect.Y = 0;
+            dragRect.Height = AppUtils.GetScalePixel(ActualHeight, AppUtils.MainWindowHandle);
+            dragRect.Width = AppUtils.GetScalePixel(ActualWidth, AppUtils.MainWindowHandle) - dragRect.X;
+
+            _appWindowTitleBar.SetDragRectangles(new[] { dragRect });
+        }
 
         private void OnBackButtonClickAsync(object sender, RoutedEventArgs e)
         {

--- a/Loaf/MainWindow.xaml
+++ b/Loaf/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <Grid x:Name="Root" Background="{ThemeResource WindowHostBrush}">
+    <Grid x:Name="Root">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/Loaf/Utils/AppUtils.cs
+++ b/Loaf/Utils/AppUtils.cs
@@ -4,23 +4,26 @@ using Microsoft.UI.Xaml;
 using System;
 using Windows.UI;
 
-namespace Loaf
+namespace Loaf.Utils
 {
     internal static class AppUtils
     {
+        public static AppWindow AppWindow;
+        public static IntPtr MainWindowHandle;
+
         public static void InitializeTitleBar(AppWindowTitleBar titleBar)
         {
-            if(titleBar == null)
+            if (titleBar == null)
             {
                 return;
             }
 
             titleBar.ExtendsContentIntoTitleBar = true;
-            if (App.Current.RequestedTheme == ApplicationTheme.Light)
+            if (Application.Current.RequestedTheme == ApplicationTheme.Light)
             {
-                titleBar.BackgroundColor = Colors.White;
+                titleBar.BackgroundColor = Colors.Transparent;
                 titleBar.InactiveBackgroundColor = Colors.White;
-                titleBar.ButtonBackgroundColor = Color.FromArgb(255, 240, 243, 249);
+                titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonForegroundColor = Colors.DarkGray;
                 titleBar.ButtonHoverBackgroundColor = Colors.LightGray;
                 titleBar.ButtonHoverForegroundColor = Colors.DarkGray;
@@ -31,9 +34,9 @@ namespace Loaf
             }
             else
             {
-                titleBar.BackgroundColor = Color.FromArgb(255, 240, 243, 249);
+                titleBar.BackgroundColor = Colors.Transparent;
                 titleBar.InactiveBackgroundColor = Colors.Black;
-                titleBar.ButtonBackgroundColor = Color.FromArgb(255, 32, 32, 32);
+                titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonForegroundColor = Colors.White;
                 titleBar.ButtonHoverBackgroundColor = Color.FromArgb(255, 20, 20, 20);
                 titleBar.ButtonHoverForegroundColor = Colors.White;

--- a/Loaf/Utils/DispatcherUtils.cs
+++ b/Loaf/Utils/DispatcherUtils.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Loaf.Utils
+{
+    internal sealed class DispatcherUtils
+    {
+        private object _dispatcherQueueController = null;
+
+        /// <inheritdoc/>
+        public void EnsureWindowsSystemDispatcherQueueController()
+        {
+            if (Windows.System.DispatcherQueue.GetForCurrentThread() != null)
+            {
+                // one already exists, so we'll just use it.
+                return;
+            }
+
+            if (_dispatcherQueueController == null)
+            {
+                DispatcherQueueOptions options;
+                options.dwSize = Marshal.SizeOf(typeof(DispatcherQueueOptions));
+                options.threadType = 2;    // DQTYPE_THREAD_CURRENT
+                options.apartmentType = 2; // DQTAT_COM_STA
+
+                CreateDispatcherQueueController(options, ref _dispatcherQueueController);
+            }
+        }
+
+        [DllImport("CoreMessaging.dll")]
+        private static extern int CreateDispatcherQueueController([In] DispatcherQueueOptions options, [In, Out, MarshalAs(UnmanagedType.IUnknown)] ref object dispatcherQueueController);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DispatcherQueueOptions
+        {
+            internal int dwSize;
+            internal int threadType;
+            internal int apartmentType;
+        }
+    }
+}


### PR DESCRIPTION
## 描述

为应用添加 Mica 材质支持，可以在 Win11 上启用 Mica 背景。
并且让应用在启动时居中

## PR类型

- 功能

## 当前行为

应用使用纯色背景，且启动后位于桌面左上角

## 新的行为

应用在 Win11 上使用 Mica 材质，启动后位于屏幕中间

## 截图

![image](https://user-images.githubusercontent.com/27713596/191875800-f8d20e02-d6ef-4625-972f-6731263b5492.png)

## 备注

1. 目前该 PR 未在 Windows 10 上测试
2. 更新背景在 Win11 上也会变成 Mica，有必要的话可以补充一个底色